### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rails_ci.yml
+++ b/.github/workflows/rails_ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Rails CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/vpn9labs/vpn9-portal/security/code-scanning/12](https://github.com/vpn9labs/vpn9-portal/security/code-scanning/12)

To address this issue, you should add a `permissions` key that sets the default permissions for jobs within this workflow. Since the steps only require checking out and reading repository code (not writing code, making releases, or changing PRs/issues), the least privilege principle applies: set `contents: read` at the workflow level. This applies read-only access to the repository contents for all jobs unless overridden at the job level. Add this block just after the `name:` statement and before the `on:` block in the `.github/workflows/rails_ci.yml` file.

**Files to edit:**  
- `.github/workflows/rails_ci.yml`, at the top-level, after `name: Rails CI`.

**Required change:**  
- Insert the following lines:
  ```yaml
  permissions:
    contents: read
  ```

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
