### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rails_ci.yml
+++ b/.github/workflows/rails_ci.yml
@@ -1,5 +1,8 @@
 name: Rails CI
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/vpn9labs/vpn9-portal/security/code-scanning/11](https://github.com/vpn9labs/vpn9-portal/security/code-scanning/11)

To address the issue, add a `permissions` block at the top (root) level of `.github/workflows/rails_ci.yml` specifying the minimal needed permissions for all jobs. In this workflow, the jobs primarily require read-only access to repository contents, so the block should be:

```yaml
permissions:
  contents: read
```

This ensures that the GITHUB_TOKEN used by the workflow has only read access to repository contents across all jobs unless overridden in specific jobs. Add this block after the `name:` and before the `on:` key, to apply it globally.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
