### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rails_ci.yml
+++ b/.github/workflows/rails_ci.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Rails CI
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/vpn9labs/vpn9-portal/security/code-scanning/10](https://github.com/vpn9labs/vpn9-portal/security/code-scanning/10)

To address this issue, we should explicitly add a `permissions` key to the workflow file. The minimal required permission for typical Rails CI workflows (checkout, scanning, linting, testing, uploading artifacts) is `contents: read`. This block can be set at the workflow (file root) level, so it applies to all jobs unless a job explicitly overrides it. Therefore, insert a `permissions: contents: read` block after the workflow `name` and before the `on:` block, i.e., as the new line 2. No imports, extra packages, or additional methods are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
