### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/reproducible-build.yml
+++ b/.github/workflows/reproducible-build.yml
@@ -288,6 +288,9 @@ jobs:
     name: Verify Reproducibility
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     if: github.event_name == 'pull_request'
     
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/vpn9labs/vpn9-portal/security/code-scanning/4](https://github.com/vpn9labs/vpn9-portal/security/code-scanning/4)

To fix the problem, add an explicit `permissions` block to the `verify` job. The minimal required permission for this job is `contents: read`. However, since the job comments on a pull request (with `github.rest.issues.createComment` in `actions/github-script`), it also requires `pull-requests: write` permission. The recommended change is to add:

```yaml
permissions:
  contents: read
  pull-requests: write
```
immediately below `runs-on: ubuntu-latest` and above `if: github.event_name == 'pull_request'` in the `verify` job definition (i.e., after line 290 and before line 291). No other functional change is required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
