### PR TITLE
Potential fix for code scanning alert no. 14: Incomplete URL substring sanitization

### DIFF
--- a/app/services/build_info/image_digest_resolver.rb
+++ b/app/services/build_info/image_digest_resolver.rb
@@ -46,7 +46,15 @@ class BuildInfo
       repo_digests = image["RepoDigests"]
       debug("ImageDigestResolver.resolve: RepoDigests count=#{repo_digests.is_a?(Array) ? repo_digests.size : 0}")
       if repo_digests.is_a?(Array) && repo_digests.any?
-        preferred = repo_digests.find { |d| d.include?("ghcr.io/") } || repo_digests.first
+        preferred = repo_digests.find do |d|
+          host = begin
+            # Docker repo digest looks like "<host>/<org>/<repo>@sha256:..."; extract the host
+            d.split("/", 2).first
+          rescue
+            nil
+          end
+          host == "ghcr.io"
+        end || repo_digests.first
         BuildInfo::ImageDigest.new(preferred.to_s)
       else
         nil


### PR DESCRIPTION
Potential fix for [https://github.com/vpn9labs/vpn9-portal/security/code-scanning/14](https://github.com/vpn9labs/vpn9-portal/security/code-scanning/14)

To fix the issue, we should replace the current substring check `.include?("ghcr.io/")` with a check that:
- Extracts the registry host domain from the repo digest string in an accurate and robust manner.
- Explicitly checks whether the host is exactly `ghcr.io`.

The format of Docker repo digests is generally:
`<registry host>/<repo>@sha256:<digest>`

So for `d = "ghcr.io/org/repo@sha256:abcd1234"`, we want to match if the registry is exactly `ghcr.io`.

We should:
1. For each `d` in `repo_digests`, parse the repo digest as a URI (prepended with `//` if needed) or split at the first `/` to get the hostname.
2. Compare the extracted host with `"ghcr.io"` for an exact, case-insensitive or exact case match.

**Region to change:**  
Modify line(s) in the block where `preferred = repo_digests.find { |d| d.include?("ghcr.io/") }` is used, replacing the substring check with correct host extraction and comparison.

**Needed:**  
- Inline code to extract the host from a Docker repo digest string.
- No new imports are needed, as `uri` is already imported.
- Code should fallback gracefully if splitting fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
